### PR TITLE
update view on main thread

### DIFF
--- a/src/ios/CameraRenderController.m
+++ b/src/ios/CameraRenderController.m
@@ -140,7 +140,9 @@
         [self.ciContext drawImage:croppedImage inRect:dest fromRect:[croppedImage extent]];
         //[self.ciContext drawImage:image inRect:dest fromRect:[image extent]];
         [self.context presentRenderbuffer:GL_RENDERBUFFER];
-        [(GLKView *)(self.view)display];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [(GLKView *)(self.view)display];
+        });
         [self.renderLock unlock];
     }
 }


### PR DESCRIPTION
```
2019-08-01 14:21:04.220726+0400 SharinPix[3708:958746] [reports] Main Thread Checker: UI API called on a background thread: -[UIViewController view]
PID: 3708, TID: 958746, Thread name: (none), Queue name: session queue, QoS: 0
Backtrace:
4   TestApp                           0x00000001002877cc -[CameraRenderController captureOutput:didOutputSampleBuffer:fromConnection:] + 2444
```