### PR TITLE
Fixed null delegate in disable on ios

### DIFF
--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -20,5 +20,5 @@
 @property (nonatomic) AVCaptureDeviceInput *videoDeviceInput;
 @property (nonatomic) AVCaptureStillImageOutput *stillImageOutput;
 @property (nonatomic) AVCaptureVideoDataOutput *dataOutput;
-@property (nonatomic, assign) id delegate;
+@property (nonatomic, weak) id delegate;
 @end

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -20,5 +20,5 @@
 @property (nonatomic) AVCaptureDeviceInput *videoDeviceInput;
 @property (nonatomic) AVCaptureStillImageOutput *stillImageOutput;
 @property (nonatomic) AVCaptureVideoDataOutput *dataOutput;
-@property (nonatomic, weak) id delegate;
+@property (nonatomic, assign) id delegate;
 @end

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -43,8 +43,6 @@
         NSLog(@"permission callback");
         if (granted) {
             dispatch_async(self.sessionQueue, ^{
-                if (!self.delegate)
-                    return completion(false);
                 NSError *error = nil;
                 BOOL success = TRUE;
                 

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -43,6 +43,8 @@
         NSLog(@"permission callback");
         if (granted) {
             dispatch_async(self.sessionQueue, ^{
+                if (!self.delegate)
+                    return completion(false);
                 NSError *error = nil;
                 BOOL success = TRUE;
                 

--- a/src/ios/SimpleCameraPreview.m
+++ b/src/ios/SimpleCameraPreview.m
@@ -52,7 +52,7 @@
 - (void) disable:(CDVInvokedUrlCommand*)command {
     NSLog(@"disable");
     [self.commandDelegate runInBackground:^{
-        CDVPluginResult *pluginResult;
+        __block CDVPluginResult *pluginResult;
         if(self.sessionManager != nil) {
             for(AVCaptureInput *input in self.sessionManager.session.inputs) {
                 [self.sessionManager.session removeInput:input];

--- a/src/ios/SimpleCameraPreview.m
+++ b/src/ios/SimpleCameraPreview.m
@@ -51,10 +51,6 @@
 
 - (void) disable:(CDVInvokedUrlCommand*)command {
     NSLog(@"disable");
-    [self.cameraRenderController.view removeFromSuperview];
-    [self.cameraRenderController removeFromParentViewController];
-    self.cameraRenderController = nil;
-    
     [self.commandDelegate runInBackground:^{
         CDVPluginResult *pluginResult;
         if(self.sessionManager != nil) {
@@ -68,6 +64,11 @@
             
             [self.sessionManager.session stopRunning];
             self.sessionManager = nil;
+            dispatch_async(dispatch_get_main_queue(), ^{
+              [self.cameraRenderController.view removeFromSuperview];
+              [self.cameraRenderController removeFromParentViewController];
+              self.cameraRenderController = nil;
+            });
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         }
         else {

--- a/src/ios/SimpleCameraPreview.m
+++ b/src/ios/SimpleCameraPreview.m
@@ -52,7 +52,6 @@
 - (void) disable:(CDVInvokedUrlCommand*)command {
     NSLog(@"disable");
     [self.commandDelegate runInBackground:^{
-        __block CDVPluginResult *pluginResult;
         if(self.sessionManager != nil) {
             for(AVCaptureInput *input in self.sessionManager.session.inputs) {
                 [self.sessionManager.session removeInput:input];
@@ -66,13 +65,11 @@
               [self.cameraRenderController.view removeFromSuperview];
               [self.cameraRenderController removeFromParentViewController];
               self.cameraRenderController = nil;
-              pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-              [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+              [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
             });
         }
         else {
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"] callbackId:command.callbackId];
         }
         
     }];

--- a/src/ios/SimpleCameraPreview.m
+++ b/src/ios/SimpleCameraPreview.m
@@ -57,24 +57,24 @@
             for(AVCaptureInput *input in self.sessionManager.session.inputs) {
                 [self.sessionManager.session removeInput:input];
             }
-            
             for(AVCaptureOutput *output in self.sessionManager.session.outputs) {
                 [self.sessionManager.session removeOutput:output];
             }
-            
             [self.sessionManager.session stopRunning];
             self.sessionManager = nil;
             dispatch_async(dispatch_get_main_queue(), ^{
               [self.cameraRenderController.view removeFromSuperview];
               [self.cameraRenderController removeFromParentViewController];
               self.cameraRenderController = nil;
+              pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+              [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             });
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         }
         else {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        
     }];
 }
 


### PR DESCRIPTION
`assign` should only be used for primitive types. [Delegates are recommended to be of `weak` type](https://stackoverflow.com/a/11013715).
https://stackoverflow.com/questions/9428500/whats-the-difference-between-weak-and-assign-in-delegate-property-declarati/9428612#9428612
ObjC properties reference:
https://www.ios-blog.com/tutorials/objective-c/objective-c-property-attribute-reference-guide/
```
Date/Time:       2019-12-14 16:36:08.000 -0800
OS Version:      iOS 13.2.3 (17B111)
Report Version:  104

Exception Type:  EXC_BAD_ACCESS (SIGBUS)
Exception Codes: KERN_EXCEPTION_PROTECTED at 0x0000000000000020
Crashed Thread:  7

Thread 7 Crashed:
0   libobjc.A.dylib                 0x0000000197120020 objc_retain + 16
1   TestApp                       0x00000001040d0838 __48-[CameraSessionManager setupSession:completion:]_block_invoke_2 (in SharinPix) (CameraSessionManager.m:93)
```

@ombr https://stackoverflow.com/questions/9428500/whats-the-difference-between-weak-and-assign-in-delegate-property-declarati/9428612#9428612
je vois pourquoi @mevinDhun doit mettre weak au lieu d'assign, mais je pense juste que si self.delegate peut pointer vers du garbage, avec weak elle pourra pointer vers nil. Mais Mevin a géré ça avec si le delegate est nil, retourner.

https://github.com/SharinPix/sharinpix-app/pull/1050