### PR TITLE
Bug fix when switching lens - SP-8604

### DIFF
--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -522,17 +522,17 @@ public class CameraPreviewFragment extends Fragment {
         if (lens != null && lens.equals("wide")) {
             cameraSelector = new CameraSelector.Builder()
                     .addCameraFilter(cameraInfos -> {
-                        List<Camera2CameraInfoImpl> backCameras = new ArrayList<>();
+                        List<Camera2CameraInfoImpl> cameras = new ArrayList<>();
                         for (CameraInfo cameraInfo : cameraInfos) {
                             if (cameraInfo instanceof Camera2CameraInfoImpl) {
                                 Camera2CameraInfoImpl camera2CameraInfo = (Camera2CameraInfoImpl) cameraInfo;
-                                if (camera2CameraInfo.getLensFacing() == CameraSelector.LENS_FACING_BACK) {
-                                    backCameras.add(camera2CameraInfo);
+                                if (camera2CameraInfo.getLensFacing() == direction) {
+                                    cameras.add(camera2CameraInfo);
                                 }
                             }
                         }
 
-                        Camera2CameraInfoImpl selectedCamera = Collections.min(backCameras, (o1, o2) -> {
+                        Camera2CameraInfoImpl selectedCamera = Collections.min(cameras, (o1, o2) -> {
                             Float focalLength1 = o1.getCameraCharacteristicsCompat().get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS)[0];
                             Float focalLength2 = o2.getCameraCharacteristicsCompat().get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS)[0];
                             return Float.compare(focalLength1, focalLength2);

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -201,44 +201,48 @@
     dispatch_async(self.sessionQueue, ^{
         BOOL cameraSwitched = FALSE;
         if (@available(iOS 13.0, *)) {
-            AVCaptureDevice *ultraWideCamera;
-            if([cameraMode isEqualToString:@"wide"]) {
-                ultraWideCamera = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInUltraWideCamera];
-            } else {
-                ultraWideCamera = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInWideAngleCamera];
+            AVCaptureDevice *selectedCamera;
+            if ([cameraMode isEqualToString:@"auto"]) {
+                selectedCamera = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInWideAngleCamera];
+            } else if ([cameraMode isEqualToString:@"wide"] && [cameraDirection isEqualToString:@"front"]) {
+                selectedCamera = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInWideAngleCamera];
             }
-            if (ultraWideCamera) {
+            else if ([cameraMode isEqualToString:@"wide"] && [self deviceHasUltraWideCamera]) {
+                selectedCamera = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+            }
+            if (selectedCamera) {
                 // Remove the current input
                 [self.session removeInput:self.videoDeviceInput];
-                
-                // Create a new input with the ultra-wide camera
+                // Create a new input with the selected camera
                 NSError *error = nil;
-                AVCaptureDeviceInput *ultraWideVideoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:ultraWideCamera error:&error];
+                AVCaptureDeviceInput *videoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:selectedCamera error:&error];
                 
                 if (!error) {
                     // Add the new input to the session
-                    if ([self.session canAddInput:ultraWideVideoDeviceInput]) {
-                        [self.session addInput:ultraWideVideoDeviceInput];
-                        self.videoDeviceInput = ultraWideVideoDeviceInput;
+                    if ([self.session canAddInput:videoDeviceInput]) {
+                        [self.session addInput:videoDeviceInput];
+                        self.videoDeviceInput = videoDeviceInput;                 
                         __block AVCaptureVideoOrientation orientation;
                         dispatch_sync(dispatch_get_main_queue(), ^{
                             orientation = [self getCurrentOrientation];
                         });
                         [self updateOrientation:orientation];
-                        self.device = ultraWideCamera;
+                        self.device = selectedCamera;
                         cameraSwitched = TRUE;
                     } else {
-                        NSLog(@"Failed to add ultra-wide input to session");
+                        NSLog(@"Failed to add camera input to session");
                     }
                 } else {
-                    NSLog(@"Error creating ultra-wide device input: %@", error.localizedDescription);
+                    NSLog(@"Error creating device input: %@", error.localizedDescription);
                 }
             } else {
-                NSLog(@"Ultra-wide camera not found");
+                NSLog(@"Requested camera lens not found");
             }
         }
         
-        completion ? completion(cameraSwitched): NULL;
+        if (completion) {
+            completion(cameraSwitched);
+        }
     });
 }
 


### PR DESCRIPTION
The bug occurs when the camera lens is set to "wide" and the direction is set to "front", causing the camera direction to fail to switch correctly to the front-facing lens, resulting in an error. Additionally, switching between lenses leads to further issues, preventing proper functionality.
