### PR TITLE
Fix issues with incompatible resolutions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.40](https://github.com/spoonconsulting/cordova-plugin-simple-camera-preview/compare/2.0.39...2.0.40) (2025-05-23)
+* **Android:** Add Aspect Ratio option
+* **iOS:** Add Aspect Ratio option
+
 ## [2.0.39](https://github.com/spoonconsulting/cordova-plugin-simple-camera-preview/compare/2.0.38...2.0.39) (2025-05-06)
 * **Android:** Enhance torch error reporting
 

--- a/README.md
+++ b/README.md
@@ -31,24 +31,25 @@ html, body, .ion-app, .ion-content {
 Make sure to set up the camera size as follows:
 
 ```javascript
-const cameraSize = this.getCameraSize();
+const aspectRatio = 3/4; // or 9/16
+const cameraSize = this.getCameraSize(aspectRatio);
 
-getCameraSize() {
+getCameraSize(aspectRatio) {
     let height;
     let width;
     const ratio = 4 / 3;
     const min = Math.min(window.innerWidth, window.innerHeight);
 
-    [width, height] = [min, Math.round(min * ratio)];
+    [width, height] = [min, Math.round(min / aspectRatio)];
     if (this.isLandscape()) {
-    [width, height] = [height, width];
+      [width, height] = [height, width];
     }
 
     return {
-    x: (window.innerWidth - width) / 2,
-    y: (window.innerHeight - height) / 2,
-    width,
-    height,
+      x: (window.innerWidth - width) / 2,
+      y: (window.innerHeight - height) / 2,
+      width,
+      height,
     };    
 }
 
@@ -65,23 +66,6 @@ Uses Google's CameraX API
 
 # Methods
 
-### setOptions(options, successCallback, errorCallback)
-
-Get the ratio for the camera preview instance (4:3, 16:9, ....).
-<br>
-
-```javascript
-const params = {
-    targetSize: 1024,
-    ...cameraSize, // use camera size 
-};
-
-SimpleCameraPreview.setOptions(params, (ratio) => {
-  console.log(ratio);
-});
-
-```
-
 ### enable(options, successCallback, errorCallback)
 
 Starts the camera preview instance.
@@ -90,7 +74,9 @@ Starts the camera preview instance.
 ```javascript
 const params = {
   targetSize: 1024,
+  lens: 'auto', // Camera lens (auto or wide). Default is auto.
   direction: 'back', // Camera direction (front or back). Default is back.
+  aspectRatio: '3:4', // Camera aspect ratoio (3:4 or 9:16). Default is 3:4.
   ...cameraSize,
 }
 
@@ -155,7 +141,7 @@ SimpleCameraPreview.deviceHasUltraWideCamera(size, (value: boolean) => {
 
 ### switchCameraTo(options, successCallback, errorCallback)
 
-Switch camera between wide or auto and set the camera direction (front or back) dynamically.
+Switch camera between wide or auto and set the camera direction (front or back) dynamically. Change camera aspect ratio.
 
 The options variable can take the following keys:
 #### Available options:
@@ -168,6 +154,9 @@ The options variable can take the following keys:
   - `"front"` – Use the front-facing camera.
   - `"back"` – Use the rear-facing camera.
 
+- **aspectRatio:**
+  - `"3:4"` – Display 3/4 preview.
+  - `"9:16"` – Display 9/16 preview.
 
 ### Note:
 Currently, the wide-angle lens functionality is not supported for the front-facing camera. If the `lens` is set to `"wide"` and the `direction` is set to `"front"`, the camera will default to the `"auto"` lens instead of switching to the wide lens.
@@ -176,6 +165,8 @@ Currently, the wide-angle lens functionality is not supported for the front-faci
 const params = {
   lens: "wide",
   direction: "back", // Specify camera direction
+  aspectRatio: "9:16", 
+  ...cameraSize,
 };
 
 SimpleCameraPreview.switchCameraTo(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spoonconsulting/cordova-plugin-simple-camera-preview",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spoonconsulting/cordova-plugin-simple-camera-preview",
-      "version": "2.0.39",
+      "version": "2.0.40",
       "license": "Apache 2.0",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spoonconsulting/cordova-plugin-simple-camera-preview",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "description": "Cordova plugin that allows camera interaction from HTML code for showing camera preview below or on top of the HTML.",
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="@spoonconsulting/cordova-plugin-simple-camera-preview" version="2.0.39" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="@spoonconsulting/cordova-plugin-simple-camera-preview" version="2.0.40" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
   <name>cordova-plugin-simple-camera-preview</name>
   <description>Cordova plugin that allows camera interaction from HTML code. Show camera preview popup on top of the HTML.</description>

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -109,10 +109,9 @@ public class CameraPreviewFragment extends Fragment {
     private static final String TAG = "SimpleCameraPreview";
     private String lens;
     private double aspectRatio;
-    private static final double ASPECT_RATIO_3_BY_4 = 4.0 / 3.0;
-    private static final double ASPECT_RATIO_9_BY_16 = 16.0 / 9.0;
+    private static final double ASPECT_RATIO_3_BY_4 = 3.0 / 4.0;
+    private static final double ASPECT_RATIO_9_BY_16 = 9.0 / 16.0;
     private Size targetResolution = null;
-
 
     public CameraPreviewFragment() {
 
@@ -239,7 +238,7 @@ public class CameraPreviewFragment extends Fragment {
         List<Size> matchingResolutions = new ArrayList<>();
         for (Size size : supportedSizes) {
             // Calculate the aspect ratio for the current resolution
-            double calculatedAspectRatio = (double) size.getWidth() / size.getHeight();
+            double calculatedAspectRatio = (double) size.getHeight() / size.getWidth();
 
             // Check if the calculated aspect ratio is close enough to the requested aspect ratio
             if (Math.abs(calculatedAspectRatio - (aspectRatio)) < 0.01) {

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -231,7 +231,8 @@ public class CameraPreviewFragment extends Fragment {
         hasUltraWideCameraCallback.onResult(defaultCamera == true && ultraWideCamera == true);
     }
 
-    public static Size calculateResolution(Context context, int desiredWidthPx, double aspectRatio) {
+     public static Size calculateResolution(Context context, int desiredWidthPx, double aspectRatio) {
+        int minWidthPx = 700;
         // 1) get all supported JPEG output sizes
         Size[] supportedSizes = getSupportedResolutions(context, CameraSelector.LENS_FACING_BACK);
 
@@ -255,7 +256,7 @@ public class CameraPreviewFragment extends Fragment {
         // 4) collect only those sizes matching the exact ratio
         List<Size> matchingResolutions = new ArrayList<>();
         for (Size size : supportedSizes) {
-            if (size.getWidth() * ratioHeight == size.getHeight() * ratioWidth) {
+            if ((size.getWidth() * ratioHeight == size.getHeight() * ratioWidth) && size.getWidth() > minWidthPx) {
                 matchingResolutions.add(size);
             }
         }

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -237,7 +237,7 @@ public class CameraPreviewFragment extends Fragment {
     }
 
     public static Size calculateResolution(Context context, int desiredWidthPx, int ratioWidth, int ratioHeight) {
-        // 1) get all supported  output sizes
+        // 1) get all supported JPEG output sizes
         Size[] supportedSizes = getSupportedResolutions(context, CameraSelector.LENS_FACING_BACK);
 
         // 2) if none available, fall back to a simple ratioWidth:ratioHeight rectangle

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -645,14 +645,12 @@ public class CameraPreviewFragment extends Fragment {
     }
 
     private int calculateCameraAspect(double aspectRatio) {
-        // Pick whichever constant is numerically closer to the requested ratio
         return Math.abs(aspectRatio - (ASPECT_RATIO_3_BY_4)) <= Math.abs(aspectRatio - (ASPECT_RATIO_9_BY_16))
             ? AspectRatio.RATIO_4_3
             : AspectRatio.RATIO_16_9;
     }
 
     private Quality calculateVideoCaptureRatio(double aspectRatio) {
-        // set video capture 9:16 for aspect ratio 9:16 and 3:4 for aspect ratio 3:4
         return Math.abs(aspectRatio - (ASPECT_RATIO_3_BY_4)) <= Math.abs(aspectRatio - (ASPECT_RATIO_9_BY_16))
             ? Quality.LOWEST
             : Quality.HD;

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -246,14 +246,14 @@ public class CameraPreviewFragment extends Fragment {
         }
 
         // If no exact matches, consider all supported sizes
-        List<Size> candidateResolutions = matchingResolutions.isEmpty()
-                ? Arrays.asList(supportedSizes)
-                : matchingResolutions;
+        if (matchingResolutions.isEmpty()) {
+            matchingResolutions = Arrays.asList(supportedSizes);
+        }
 
         if (desiredWidthPx <= 0) {
             // If no target size specified, return the highest resolution that matches the aspect ratio
-            Size highestResolution = candidateResolutions.get(0);
-            for (Size candidate : candidateResolutions) {
+            Size highestResolution = matchingResolutions.get(0);
+            for (Size candidate : matchingResolutions) {
                 if (candidate.getWidth() > highestResolution.getWidth()) {
                     highestResolution = candidate;
                 }
@@ -262,9 +262,9 @@ public class CameraPreviewFragment extends Fragment {
         }
 
         // Pick the one whose width is closest to desiredWidthPx
-        Size bestMatch = candidateResolutions.get(0);
+        Size bestMatch = matchingResolutions.get(0);
         int smallestDifference = Math.abs(bestMatch.getWidth() - desiredWidthPx);
-        for (Size candidate : candidateResolutions) {
+        for (Size candidate : matchingResolutions) {
             int difference = Math.abs(candidate.getWidth() - desiredWidthPx);
             if (difference < smallestDifference) {
                 smallestDifference = difference;
@@ -534,7 +534,7 @@ public class CameraPreviewFragment extends Fragment {
         }
         return backCameras;
     }
-    
+
     @SuppressLint("RestrictedApi")
     private void setCameraSelector() {
         if (lens.equals("wide") && direction != CameraSelector.LENS_FACING_FRONT) {

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -556,6 +556,16 @@ public class CameraPreviewFragment extends Fragment {
                 return;
             }
 
+            double currentAspectRatio = this.aspectRatio;
+            try {
+                if (options.has("aspectRatio")) {
+                    this.aspectRatio = options.getDouble("aspectRatio");
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+                this.aspectRatio = currentAspectRatio;
+            }
+
             setUpCamera(options, cameraProvider);
             preview.setSurfaceProvider(viewFinder.getSurfaceProvider());
             cameraSwitchedCallback.onSwitch(true);
@@ -575,6 +585,14 @@ public class CameraPreviewFragment extends Fragment {
             direction = options.getInt("direction");
         } catch (JSONException e) {
             direction = CameraSelector.LENS_FACING_BACK;
+        }
+
+        try {
+            if (options.has("aspectRatio")) {
+                aspectRatio = options.getDouble("aspectRatio");
+            }
+        } catch (JSONException e) {
+            Log.d(TAG, "Keeping current aspect ratio: " + aspectRatio);
         }
 
         if (lens != null && lens.equals("wide") && direction != CameraSelector.LENS_FACING_FRONT) {
@@ -647,9 +665,9 @@ public class CameraPreviewFragment extends Fragment {
                     videoCapture
             );
         } catch (IllegalArgumentException e) {
-            // Error with result in capturing image with default resolution
             e.printStackTrace();
             imageCapture = new ImageCapture.Builder()
+                    .setResolutionSelector(resolutionSelector)
                     .build();
             camera = cameraProvider.bindToLifecycle(
                     getActivity(),

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -109,8 +109,8 @@ public class CameraPreviewFragment extends Fragment {
     private static final String TAG = "SimpleCameraPreview";
     private String lens;
     private double aspectRatio;
-    private static final double ASPECT_RATIO_3_BY_4 = 1.3333;
-    private static final double ASPECT_RATIO_9_BY_16 = 1.7777;
+    private static final double ASPECT_RATIO_3_BY_4 = 4.0 / 3.0;
+    private static final double ASPECT_RATIO_9_BY_16 = 16.0 / 9.0;
     private Size targetResolution = null;
 
 
@@ -123,26 +123,26 @@ public class CameraPreviewFragment extends Fragment {
         try {
             this.direction = options.getInt("direction");
         } catch (JSONException e) {
-            e.printStackTrace();
             this.direction = CameraSelector.LENS_FACING_BACK;
+            e.printStackTrace();
         }
         try {
             this.targetSize = options.getInt("targetSize");
         } catch (JSONException e) {
-            e.printStackTrace();
             this.targetSize = 0;
+            e.printStackTrace();
         }
         try {
             this.lens = options.getString("lens");
         } catch (JSONException e) {
-            e.printStackTrace();
             this.lens = "default";
+            e.printStackTrace();
         }
         try {
             this.aspectRatio = options.getDouble("aspectRatio");
         } catch (JSONException e) {
-            e.printStackTrace();
             this.aspectRatio = ASPECT_RATIO_3_BY_4;
+            e.printStackTrace();
         }
         startCameraCallback = cameraStartedCallback;
     }
@@ -234,14 +234,6 @@ public class CameraPreviewFragment extends Fragment {
     public static Size calculateResolution(Context context, int desiredWidthPx, double aspectRatio) {
         // Get all supported JPEG output sizes
         Size[] supportedSizes = getSupportedResolutions(context, CameraSelector.LENS_FACING_BACK);
-
-        // If none available, fall back to a simple ratioWidth:ratioHeight rectangle
-        if (supportedSizes.length == 0) {
-            int fallbackHeight = Math.round(
-                    desiredWidthPx / (float) aspectRatio
-            );
-            return new Size(desiredWidthPx, fallbackHeight);
-        }
 
         // Collect only those sizes matching the exact ratio
         List<Size> matchingResolutions = new ArrayList<>();
@@ -345,7 +337,7 @@ public class CameraPreviewFragment extends Fragment {
             camera.getCameraControl().enableTorch(torchOn).get();
             torchCallback.onEnabled(null);
         } catch (Exception e) {
-            torchCallback.onEnabled(new Exception("Failed to switch " + (torchOn ? "on" : "off") + " torch: " + e.getMessage()));
+            torchCallback.onEnabled(new Exception("Failed to switch " + (torchOn ? "on" : "off") + " torch: " + e.getMessage(), e));
             return;
         }
 
@@ -430,7 +422,7 @@ public class CameraPreviewFragment extends Fragment {
 
         size = info.getResolution();
         if (this.targetSize > 0 && targetResolution != null) {
-            size = targetResolution;
+            size = this.targetResolution;
         }
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
@@ -551,8 +543,8 @@ public class CameraPreviewFragment extends Fragment {
                 cameraProvider = cameraProviderFuture.get();
             } catch (ExecutionException | InterruptedException e) {
                 Log.e(TAG, "Error occurred while trying to obtain the camera provider: " + e.getMessage());
-                e.printStackTrace();
                 cameraSwitchedCallback.onSwitch(false);
+                e.printStackTrace();
                 return;
             }
 
@@ -562,8 +554,9 @@ public class CameraPreviewFragment extends Fragment {
                     this.aspectRatio = options.getDouble("aspectRatio");
                 }
             } catch (JSONException e) {
-                e.printStackTrace();
                 this.aspectRatio = currentAspectRatio;
+                e.printStackTrace();
+
             }
 
             setUpCamera(options, cameraProvider);
@@ -627,8 +620,8 @@ public class CameraPreviewFragment extends Fragment {
                     .build();
         }
 
-        targetResolution = calculateResolution(getContext(), targetSize, aspectRatio);
-        videoCapture = VideoCapture.withOutput(new Recorder.Builder()
+        this.targetResolution = calculateResolution(getContext(), targetSize, aspectRatio);
+        this.videoCapture = VideoCapture.withOutput(new Recorder.Builder()
                 .setQualitySelector(QualitySelector.from(calculateVideoCaptureRatio(aspectRatio)))
                 .build());
 

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -628,11 +628,9 @@ public class CameraPreviewFragment extends Fragment {
         }
 
         targetResolution = calculateResolution(getContext(), targetSize, aspectRatio);
-
-        Recorder recorder = new Recorder.Builder()
-                .setQualitySelector(QualitySelector.from(Quality.LOWEST))
-                .build();
-        videoCapture = VideoCapture.withOutput(recorder);
+        videoCapture = VideoCapture.withOutput(new Recorder.Builder()
+                .setQualitySelector(QualitySelector.from(calculateVideoCaptureRatio(aspectRatio)))
+                .build());
 
         int cameraAspectRatio = calculateCameraAspect(aspectRatio);
         preview = new Preview.Builder().build();
@@ -654,6 +652,7 @@ public class CameraPreviewFragment extends Fragment {
         imageCapture = new ImageCapture.Builder()
                 .setResolutionSelector(resolutionSelector)
                 .build();
+
 
         cameraProvider.unbindAll();
         try {
@@ -682,8 +681,15 @@ public class CameraPreviewFragment extends Fragment {
     private int calculateCameraAspect(double aspectRatio) {
         // Pick whichever constant is numerically closer to the requested ratio
         return Math.abs(aspectRatio - (ASPECT_RATIO_3_BY_4)) <= Math.abs(aspectRatio - (ASPECT_RATIO_9_BY_16))
-                ? AspectRatio.RATIO_4_3
-                : AspectRatio.RATIO_16_9;
+            ? AspectRatio.RATIO_4_3
+            : AspectRatio.RATIO_16_9;
+    }
+
+    private Quality calculateVideoCaptureRatio(double aspectRatio) {
+        // set video capture 9:16 for aspect ratio 9:16 and 3:4 for aspect ratio 3:4
+        return Math.abs(aspectRatio - (ASPECT_RATIO_3_BY_4)) <= Math.abs(aspectRatio - (ASPECT_RATIO_9_BY_16))
+            ? Quality.LOWEST
+            : Quality.HD;
     }
 
     @Override

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -233,10 +233,10 @@ public class CameraPreviewFragment extends Fragment {
 
      public static Size calculateResolution(Context context, int desiredWidthPx, double aspectRatio) {
         int minWidthPx = 700;
-        // 1) get all supported JPEG output sizes
+        // get all supported JPEG output sizes
         Size[] supportedSizes = getSupportedResolutions(context, CameraSelector.LENS_FACING_BACK);
 
-        // 2) if none available, fall back to a simple ratioWidth:ratioHeight rectangle
+        // if none available, fall back to a simple ratioWidth:ratioHeight rectangle
         if (supportedSizes.length == 0) {
             int fallbackHeight = Math.round(
                     desiredWidthPx / (float) aspectRatio
@@ -244,16 +244,16 @@ public class CameraPreviewFragment extends Fragment {
             return new Size(desiredWidthPx, fallbackHeight);
         }
 
-        int ratioWidth  = 4;
-        int ratioHeight = 3;
+        double ratioWidth  = 4.0;
+        double ratioHeight = 3.0;
 
-        // 3) pick the ratioWidth:ratioHeight rectangle closest to the requested aspect ratio
+        // pick the ratioWidth:ratioHeight rectangle closest to the requested aspect ratio
         if (Math.abs(aspectRatio - (ASPECT_RATIO_4_BY_3)) > Math.abs(aspectRatio - (ASPECT_RATIO_16_BY_9))) {
-            ratioWidth  = 16;
-            ratioHeight = 9;
+            ratioWidth  = 16.0;
+            ratioHeight = 9.0;
         }
 
-        // 4) collect only those sizes matching the exact ratio
+        // collect only those sizes matching the exact ratio
         List<Size> matchingResolutions = new ArrayList<>();
         for (Size size : supportedSizes) {
             if ((size.getWidth() * ratioHeight == size.getHeight() * ratioWidth) && size.getWidth() > minWidthPx) {
@@ -261,12 +261,12 @@ public class CameraPreviewFragment extends Fragment {
             }
         }
 
-        // 5) if no exact matches, consider all supported sizes
+        // if no exact matches, consider all supported sizes
         List<Size> candidateResolutions = matchingResolutions.isEmpty()
                 ? Arrays.asList(supportedSizes)
                 : matchingResolutions;
 
-        // 6) pick the one whose width is closest to desiredWidthPx
+        // pick the one whose width is closest to desiredWidthPx
         Size bestMatch = candidateResolutions.get(0);
         int smallestDifference = Math.abs(bestMatch.getWidth() - desiredWidthPx);
         for (Size candidate : candidateResolutions) {
@@ -424,11 +424,8 @@ public class CameraPreviewFragment extends Fragment {
         if (info == null) { return thumbnailUri; }
 
         size = info.getResolution();
-
-        if (this.targetSize > 0) {
-            if (targetResolution != null){
-                size = targetResolution;
-            }
+        if (this.targetSize > 0 && targetResolution != null) {
+            size = targetResolution;
         }
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -760,6 +760,18 @@ public class CameraPreviewFragment extends Fragment {
     //     }
     // }
 
+     private static int aspectRatioFromSize(Size size) {
+        int width = size.getWidth();
+        int height = size.getHeight();
+        double previewRatio = (double) Math.max(width, height) / Math.min(width, height);
+
+        if (Math.abs(previewRatio - (4.0 / 3.0)) <= Math.abs(previewRatio - (16.0 / 9.0))) {
+            return AspectRatio.RATIO_4_3;
+        } else {
+            return AspectRatio.RATIO_16_9;
+        }
+    }
+
     @Override
     public void onPause() {
         super.onPause();

--- a/src/android/CameraPreviewFragment.java
+++ b/src/android/CameraPreviewFragment.java
@@ -108,9 +108,9 @@ public class CameraPreviewFragment extends Fragment {
     private boolean torchActivated = false;
     private static final String TAG = "SimpleCameraPreview";
     private String lens;
-    private Double aspectRatio;
-    private static final double ASPECT_RATIO_4_BY_3 = 4.0 / 3.0;
-    private static final double ASPECT_RATIO_16_BY_9 = 16.0 / 9.0;
+    private double aspectRatio;
+    private static final double ASPECT_RATIO_3_BY_4 = 1.3333;
+    private static final double ASPECT_RATIO_9_BY_16 = 1.7777;
     private Size targetResolution = null;
 
 
@@ -139,10 +139,10 @@ public class CameraPreviewFragment extends Fragment {
             this.lens = "default";
         }
         try {
-        this.aspectRatio = options.getDouble("aspectRatio");
+            this.aspectRatio = options.getDouble("aspectRatio");
         } catch (JSONException e) {
             e.printStackTrace();
-            this.aspectRatio = ASPECT_RATIO_4_BY_3;
+            this.aspectRatio = ASPECT_RATIO_3_BY_4;
         }
         startCameraCallback = cameraStartedCallback;
     }
@@ -243,25 +243,18 @@ public class CameraPreviewFragment extends Fragment {
             );
             return new Size(desiredWidthPx, fallbackHeight);
         }
-
-        double ratioWidth  = 4.0;
-        double ratioHeight = 3.0;
-
-        // pick the ratioWidth:ratioHeight rectangle closest to the requested aspect ratio
-        if (Math.abs(aspectRatio - (ASPECT_RATIO_4_BY_3)) > Math.abs(aspectRatio - (ASPECT_RATIO_16_BY_9))) {
-            ratioWidth  = 16.0;
-            ratioHeight = 9.0;
-        }
-
         // collect only those sizes matching the exact ratio
-        List<Size> matchingResolutions = new ArrayList<>();
-        for (Size size : supportedSizes) {
-            if ((size.getWidth() * ratioHeight == size.getHeight() * ratioWidth) && size.getWidth() > minWidthPx) {
-                matchingResolutions.add(size);
-            }
-        }
+         List<Size> matchingResolutions = new ArrayList<>();
+         for (Size size : supportedSizes) {
+             // Calculate the aspect ratio for the current resolution
+             double calculatedAspectRatio = (double) size.getWidth() / size.getHeight();
 
-        // if no exact matches, consider all supported sizes
+             // Check if the calculated aspect ratio is close enough to the requested aspect ratio
+             if (Math.abs(calculatedAspectRatio - (aspectRatio)) < 0.01 && size.getWidth() > minWidthPx) {
+                 matchingResolutions.add(size);
+             }
+         }
+         // if no exact matches, consider all supported sizes
         List<Size> candidateResolutions = matchingResolutions.isEmpty()
                 ? Arrays.asList(supportedSizes)
                 : matchingResolutions;
@@ -657,8 +650,8 @@ public class CameraPreviewFragment extends Fragment {
     }
 
     private int calculateCameraAspect(double aspectRatio) {
-        // whichever constant is numerically closer to the requested ratio
-        return Math.abs(aspectRatio - (ASPECT_RATIO_4_BY_3)) <= Math.abs(aspectRatio - (ASPECT_RATIO_16_BY_9))
+        // Pick whichever constant is numerically closer to the requested ratio
+        return Math.abs(aspectRatio - (ASPECT_RATIO_3_BY_4)) <= Math.abs(aspectRatio - (ASPECT_RATIO_9_BY_16))
                 ? AspectRatio.RATIO_4_3
                 : AspectRatio.RATIO_16_9;
     }

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -237,10 +237,11 @@ public class SimpleCameraPreview extends CordovaPlugin {
 
         double aspectRatio = 4.0 / 3.0;
         try {
-            if (options.getString("aspectRatio") != null && !options.getString("aspectRatio").equals("null")) {
-                aspectRatio = Double.parseDouble(options.getString("aspectRatio"));
+            if (options.has("aspectRatio") && !options.isNull("aspectRatio")) {
+                aspectRatio = options.getDouble("aspectRatio");
+
             }
-        
+
         } catch (JSONException | NumberFormatException e) {
             e.printStackTrace();
         }

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -210,18 +210,6 @@ public class SimpleCameraPreview extends CordovaPlugin {
         return true;
     }
 
-    public static Double getAspectRatioDouble(int width, int height) {
-        int gcd = getGCD(width, height);
-        int aspectWidth = width / gcd;
-        int aspectHeight = height / gcd;
-        return (double) aspectWidth / (double) aspectHeight;
-    }
-
-    private static int getGCD(int a, int b) {
-        if (b == 0) return a;
-        return getGCD(b, a % b);
-    }
-
     private boolean setOptions(JSONObject options, CallbackContext callbackContext) {
         int targetSize = 0;
         try {
@@ -235,8 +223,8 @@ public class SimpleCameraPreview extends CordovaPlugin {
             if (targetSize > 0) {
                 DisplayMetrics metrics = cordova.getContext().getResources().getDisplayMetrics();
                 int targetSizePx = Math.round(targetSize * metrics.density);
-                Size targetResolution = CameraPreviewFragment.calculateResolution(cordova.getContext(), targetSizePx);
-                double ratio = getAspectRatioDouble(targetResolution.getWidth(),targetResolution.getHeight());
+                Size targetResolution = CameraPreviewFragment.calculateResolution(cordova.getContext(), targetSizePx, 4, 3);
+                double ratio = (double) targetResolution.getWidth() / (double) targetResolution.getHeight();
                 PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, String.valueOf(ratio));
                 callbackContext.sendPluginResult(pluginResult);
 

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -54,8 +54,6 @@ public class SimpleCameraPreview extends CordovaPlugin {
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
         try {
             switch (action) {
-                case "setOptions":
-                    return setOptions((JSONObject) args.get(0), callbackContext);
 
                 case "enable":
                     return enable((JSONObject) args.get(0), callbackContext);
@@ -211,38 +209,6 @@ public class SimpleCameraPreview extends CordovaPlugin {
         return true;
     }
 
-    private boolean setOptions(JSONObject options, CallbackContext callbackContext) {
-        int targetSize = 0;
-        int aspectX = 4, aspectY = 3;
-        try {
-            if (options.getString("targetSize") != null && !options.getString("targetSize").equals("null")) {
-                targetSize = Integer.parseInt(options.getString("targetSize"));
-            }
-            if (options.getString("aspectRatio") != null && !options.getString("aspectRatio").equals("null")) {
-                String[] parts = options.getString("aspectRatio").split(":");
-                if (parts.length == 2) {
-                    aspectX  = Integer.parseInt(parts[0]);
-                    aspectY = Integer.parseInt(parts[1]);
-                }
-            }
-        } catch (JSONException | NumberFormatException e) {
-            e.printStackTrace();
-        }
-        try {
-            if (targetSize > 0) {
-                double ratio = (double) aspectX / (double) aspectY;
-                PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, String.valueOf(ratio));
-                callbackContext.sendPluginResult(pluginResult);
-
-            }
-            return true;
-        } catch (Exception e) {
-            e.printStackTrace();
-            callbackContext.error(e.getMessage());
-            return false;
-        }
-    }
-
     private boolean enable(JSONObject options, CallbackContext callbackContext) {
         webView.getView().setBackgroundColor(0x00000000);
         // Request focus on webView as page needs to be clicked/tapped to get focus on page events
@@ -269,15 +235,12 @@ public class SimpleCameraPreview extends CordovaPlugin {
             e.printStackTrace();
         }
 
-        int aspectX = 4, aspectY = 3;
+        double aspectRatio = 4.0 / 3.0;
         try {
             if (options.getString("aspectRatio") != null && !options.getString("aspectRatio").equals("null")) {
-                String[] parts = options.getString("aspectRatio").split(":");
-                if (parts.length == 2) {
-                    aspectX  = Integer.parseInt(parts[0]);
-                    aspectY = Integer.parseInt(parts[1]);
-                }
+                aspectRatio = Double.parseDouble(options.getString("aspectRatio"));
             }
+        
         } catch (JSONException | NumberFormatException e) {
             e.printStackTrace();
         }
@@ -308,12 +271,7 @@ public class SimpleCameraPreview extends CordovaPlugin {
             e.printStackTrace();
         }
         try {
-            cameraPreviewOptions.put("aspectX", aspectX);
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-        try {
-            cameraPreviewOptions.put("aspectY", aspectY);
+            cameraPreviewOptions.put("aspectRatio", aspectRatio);
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -196,7 +196,6 @@ public class SimpleCameraPreview extends CordovaPlugin {
         return true;
     }
 
-
     private boolean stopVideoCapture(CallbackContext callbackContext) {
         if (fragment == null) {
             callbackContext.error("Camera is closed");
@@ -232,10 +231,8 @@ public class SimpleCameraPreview extends CordovaPlugin {
         } catch (JSONException | NumberFormatException e) {
             e.printStackTrace();
         }
-        int lensFacing = CameraCharacteristics.LENS_FACING_BACK;
         try {
             if (targetSize > 0) {
-
                 DisplayMetrics metrics = cordova.getContext().getResources().getDisplayMetrics();
                 int targetSizePx = Math.round(targetSize * metrics.density);
                 Size targetResolution = CameraPreviewFragment.calculateResolution(cordova.getContext(), targetSizePx);

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -14,6 +14,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.util.Size;
 import android.view.ViewGroup;
 import android.view.ViewParent;
@@ -217,12 +218,13 @@ public class SimpleCameraPreview extends CordovaPlugin {
             if (options.getString("targetSize") != null && !options.getString("targetSize").equals("null")) {
                 targetSize = Integer.parseInt(options.getString("targetSize"));
             }
-
-            if (options.getString("aspectX") != null && !options.getString("aspectX").equals("null") && options.getString("aspectY") != null && !options.getString("aspectY").equals("null")) {
-                aspectX = Integer.parseInt(options.getString("aspectX"));
-                aspectY = Integer.parseInt(options.getString("aspectY"));
+            if (options.getString("aspectRatio") != null && !options.getString("aspectRatio").equals("null")) {
+                String[] parts = options.getString("aspectRatio").split(":");
+                if (parts.length == 2) {
+                    aspectX  = Integer.parseInt(parts[0]);
+                    aspectY = Integer.parseInt(parts[1]);
+                }
             }
-            
         } catch (JSONException | NumberFormatException e) {
             e.printStackTrace();
         }
@@ -269,10 +271,12 @@ public class SimpleCameraPreview extends CordovaPlugin {
 
         int aspectX = 4, aspectY = 3;
         try {
-            if (options.getString("aspectX") != null && !options.getString("aspectX").equals("null")
-                    && options.getString("aspectY") != null && !options.getString("aspectY").equals("null")) {
-                aspectX = Integer.parseInt(options.getString("aspectX"));
-                aspectY = Integer.parseInt(options.getString("aspectY"));
+            if (options.getString("aspectRatio") != null && !options.getString("aspectRatio").equals("null")) {
+                String[] parts = options.getString("aspectRatio").split(":");
+                if (parts.length == 2) {
+                    aspectX  = Integer.parseInt(parts[0]);
+                    aspectY = Integer.parseInt(parts[1]);
+                }
             }
         } catch (JSONException | NumberFormatException e) {
             e.printStackTrace();

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -235,7 +235,7 @@ public class SimpleCameraPreview extends CordovaPlugin {
             e.printStackTrace();
         }
 
-        double aspectRatio = 1.333 // Default aspect ratio 3:4
+        double aspectRatio = 1.333; // Default aspect ratio 3:4
         try {
             if (options.getString("aspectRatio") != null && !options.getString("aspectRatio").equals("null")) {
                 String aspectRatioString = options.getString("aspectRatio");

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -212,19 +212,23 @@ public class SimpleCameraPreview extends CordovaPlugin {
 
     private boolean setOptions(JSONObject options, CallbackContext callbackContext) {
         int targetSize = 0;
+        int aspectX = 4, aspectY = 3;
         try {
             if (options.getString("targetSize") != null && !options.getString("targetSize").equals("null")) {
                 targetSize = Integer.parseInt(options.getString("targetSize"));
             }
+
+            if (options.getString("aspectX") != null && !options.getString("aspectX").equals("null") && options.getString("aspectY") != null && !options.getString("aspectY").equals("null")) {
+                aspectX = Integer.parseInt(options.getString("aspectX"));
+                aspectY = Integer.parseInt(options.getString("aspectY"));
+            }
+            
         } catch (JSONException | NumberFormatException e) {
             e.printStackTrace();
         }
         try {
             if (targetSize > 0) {
-                DisplayMetrics metrics = cordova.getContext().getResources().getDisplayMetrics();
-                int targetSizePx = Math.round(targetSize * metrics.density);
-                Size targetResolution = CameraPreviewFragment.calculateResolution(cordova.getContext(), targetSizePx, 4, 3);
-                double ratio = (double) targetResolution.getWidth() / (double) targetResolution.getHeight();
+                double ratio = (double) aspectX / (double) aspectY;
                 PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, String.valueOf(ratio));
                 callbackContext.sendPluginResult(pluginResult);
 
@@ -263,6 +267,17 @@ public class SimpleCameraPreview extends CordovaPlugin {
             e.printStackTrace();
         }
 
+        int aspectX = 4, aspectY = 3;
+        try {
+            if (options.getString("aspectX") != null && !options.getString("aspectX").equals("null")
+                    && options.getString("aspectY") != null && !options.getString("aspectY").equals("null")) {
+                aspectX = Integer.parseInt(options.getString("aspectX"));
+                aspectY = Integer.parseInt(options.getString("aspectY"));
+            }
+        } catch (JSONException | NumberFormatException e) {
+            e.printStackTrace();
+        }
+
         String lens = "default";
         try {
             if (options.getString("lens") != null && !options.getString("lens").equals("null")) {
@@ -285,6 +300,16 @@ public class SimpleCameraPreview extends CordovaPlugin {
         }
         try {
             cameraPreviewOptions.put("direction", cameraDirection);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        try {
+            cameraPreviewOptions.put("aspectX", aspectX);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        try {
+            cameraPreviewOptions.put("aspectY", aspectY);
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -443,7 +443,7 @@ public class SimpleCameraPreview extends CordovaPlugin {
                  width = Double.parseDouble(ratioParts[0]);
                  height = Double.parseDouble(ratioParts[1]);
             }
-            return height / width;
+            return width / height;
 
         } catch (JSONException e) {
             return DEFAULT_ASPECT_RATIO;

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -235,11 +235,16 @@ public class SimpleCameraPreview extends CordovaPlugin {
             e.printStackTrace();
         }
 
-        double aspectRatio = 4.0 / 3.0;
+        double aspectRatio = 1.333 // Default aspect ratio 3:4
         try {
-            if (options.has("aspectRatio") && !options.isNull("aspectRatio")) {
-                aspectRatio = options.getDouble("aspectRatio");
-
+            if (options.getString("aspectRatio") != null && !options.getString("aspectRatio").equals("null")) {
+                String aspectRatioString = options.getString("aspectRatio");
+                String[] aspectRatioParts = aspectRatioString.split(":");
+                if (aspectRatioParts.length == 2) {
+                    double aspectRatioWidth = Double.parseDouble(aspectRatioParts[0]);
+                    double aspectRatioHeight = Double.parseDouble(aspectRatioParts[1]);
+                    aspectRatio = aspectRatioHeight/aspectRatioWidth;
+                }
             }
 
         } catch (JSONException | NumberFormatException e) {

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
-import android.hardware.camera2.CameraCharacteristics;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
@@ -14,8 +13,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
-import android.util.Log;
-import android.util.Size;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.widget.FrameLayout;
@@ -45,7 +42,7 @@ public class SimpleCameraPreview extends CordovaPlugin {
     private static final int REQUEST_CODE_PERMISSIONS = 4582679;
     private static final int VIDEO_REQUEST_CODE_PERMISSIONS = 200;
     private static final String REQUIRED_PERMISSION = Manifest.permission.CAMERA;
-    private static final double DEFAULT_ASPECT_RATIO = 1.33333;
+    private static final double DEFAULT_ASPECT_RATIO = 4.0 / 3.0;
 
     public SimpleCameraPreview() {
         super();
@@ -441,7 +438,7 @@ public class SimpleCameraPreview extends CordovaPlugin {
         try {
             String aspectRatio = options.getString("aspectRatio");
             String[] ratioParts = aspectRatio.split(":");
-            double width =0,height = 0;
+            double width = 0,height = 0;
             if (ratioParts.length == 2) {
                  width = Double.parseDouble(ratioParts[0]);
                  height = Double.parseDouble(ratioParts[1]);

--- a/src/android/SimpleCameraPreview.java
+++ b/src/android/SimpleCameraPreview.java
@@ -42,7 +42,7 @@ public class SimpleCameraPreview extends CordovaPlugin {
     private static final int REQUEST_CODE_PERMISSIONS = 4582679;
     private static final int VIDEO_REQUEST_CODE_PERMISSIONS = 200;
     private static final String REQUIRED_PERMISSION = Manifest.permission.CAMERA;
-    private static final double DEFAULT_ASPECT_RATIO = 4.0 / 3.0;
+    private static final double DEFAULT_ASPECT_RATIO = 3.0 / 4.0;
 
     public SimpleCameraPreview() {
         super();

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -16,7 +16,7 @@
 - (void) stopRecording;
 - (void) startSession;
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
-+ (AVCaptureSessionPreset)calculateResolution:(NSInteger)targetSize aspectRatio:(NSString *)aspectRatio;
+- (AVCaptureSessionPreset)calculateResolution:(NSInteger)targetSize aspectRatio:(NSString *)aspectRatio;
 - (UIInterfaceOrientation) getOrientation;
 
 @property (atomic) CIFilter *ciFilter;
@@ -32,6 +32,6 @@
 @property (nonatomic, weak) id delegate;
 @property (nonatomic) AVCaptureMovieFileOutput *movieFileOutput;
 @property (nonatomic) NSTimer *videoTimer;
-@property (nonatomic, assign) NSInteger targetSize;
-@property (nonatomic, strong) NSString *aspectRatio;
+@property (nonatomic) NSInteger targetSize;
+@property (nonatomic) NSString *aspectRatio;
 @end

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -16,7 +16,7 @@
 - (void) stopRecording;
 - (void) startSession;
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
-+ (AVCaptureSessionPreset) calculateResolution:(NSInteger)targetSize;
++ (AVCaptureSessionPreset)calculateResolution:(NSInteger)targetSize aspectRatio:(NSString *)aspectRatio;
 - (UIInterfaceOrientation) getOrientation;
 
 @property (atomic) CIFilter *ciFilter;
@@ -32,4 +32,6 @@
 @property (nonatomic, weak) id delegate;
 @property (nonatomic) AVCaptureMovieFileOutput *movieFileOutput;
 @property (nonatomic) NSTimer *videoTimer;
+@property (nonatomic, assign) NSInteger targetSize;
+@property (nonatomic, strong) NSString *aspectRatio;
 @end

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -61,7 +61,13 @@
                         videoDevice = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInUltraWideCamera];
                     }
                 }
-                
+
+                self.aspectRatio = @"3:4";
+                NSString *aspectRatio = options[@"aspectRatio"];
+                   if (aspectRatio && [aspectRatio length] > 0) {
+                       self.aspectRatio = aspectRatio;
+                   } 
+
                 if ([videoDevice hasFlash]) {
                     if ([videoDevice lockForConfiguration:&error]) {
                         photoSettings.flashMode = AVCaptureFlashModeAuto;
@@ -79,11 +85,10 @@
                 
                 if (options) {
                     NSInteger targetSize = ((NSNumber*)options[@"targetSize"]).intValue;
-                    if (targetSize > 0) {
-                        AVCaptureSessionPreset calculatedPreset = [CameraSessionManager calculateResolution:targetSize];
-                        if ([self.session canSetSessionPreset:calculatedPreset]) {
-                            [self.session setSessionPreset:calculatedPreset];
-                        }
+                    self.targetSize = targetSize;
+                    AVCaptureSessionPreset calculatedPreset = [CameraSessionManager calculateResolution:self.targetSize aspectRatio:self.aspectRatio];
+                    if ([self.session canSetSessionPreset:calculatedPreset]) {
+                        [self.session setSessionPreset:calculatedPreset];
                     }
                 }
 
@@ -151,18 +156,47 @@
     });
 }
 
-+ (AVCaptureSessionPreset) calculateResolution:(NSInteger)targetSize {
-    if (targetSize >= 3840) {
-        return AVCaptureSessionPreset3840x2160;
-    } else if (targetSize >= 1920) {
-        return AVCaptureSessionPreset1920x1080;
-    } else if (targetSize >= 1280) {
-        return AVCaptureSessionPreset1280x720;
-    } else if (targetSize >= 640) {
-        return AVCaptureSessionPreset640x480;
-    } else {
-        return AVCaptureSessionPreset352x288;
++ (AVCaptureSessionPreset)calculateResolution:(NSInteger)targetSize aspectRatio:(NSString *)aspectRatio {
+    NSArray<NSDictionary *> *presets = @[
+        @{@"preset": AVCaptureSessionPreset3840x2160, @"width": @(3840), @"aspect": @"9:16"},
+        @{@"preset": AVCaptureSessionPreset1920x1080, @"width": @(1920), @"aspect": @"9:16"},
+        @{@"preset": AVCaptureSessionPreset1280x720,  @"width": @(1280), @"aspect": @"9:16"},
+        @{@"preset": AVCaptureSessionPreset640x480,   @"width": @(640),  @"aspect": @"3:4"},
+        @{@"preset": AVCaptureSessionPreset352x288,   @"width": @(352),  @"aspect": @"3:4"},
+    ];
+    
+    NSString *normalizedAspect = [aspectRatio isEqualToString:@"9:16"] ? @"9:16" : @"3:4";
+    if ([normalizedAspect isEqualToString:@"3:4"]) {
+        return AVCaptureSessionPresetPhoto;
     }
+    
+    NSPredicate *aspectPredicate = [NSPredicate predicateWithFormat:@"aspect == %@", normalizedAspect];
+    NSArray *filteredPresets = [presets filteredArrayUsingPredicate:aspectPredicate];
+    
+    // Return highest resolution if targetsize not specify for aspect ratio 9:16
+    if (targetSize <= 0) {
+        return filteredPresets.firstObject[@"preset"];
+    }
+    
+    // Find preset with closest width to targetSize
+    NSDictionary *closestPreset = nil;
+    NSInteger smallestDifference = NSIntegerMax;
+    
+    for (NSDictionary *presetInfo in filteredPresets) {
+        NSInteger width = [presetInfo[@"width"] integerValue];
+        NSInteger difference = abs((int)(width - targetSize));
+        
+        if (difference < smallestDifference) {
+            smallestDifference = difference;
+            closestPreset = presetInfo;
+        }
+    }
+    
+    if (closestPreset) {
+        return closestPreset[@"preset"];
+    }
+    
+    return presets[0][@"preset"];
 }
 
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation {
@@ -202,6 +236,13 @@
 - (void)switchCameraTo:(NSDictionary*)cameraOptions completion:(void (^)(BOOL success))completion {
     NSString* cameraMode = cameraOptions[@"lens"];
     NSString* cameraDirection = cameraOptions[@"direction"];
+    NSString* aspectRatio = cameraOptions[@"aspectRatio"];
+
+    if (aspectRatio && [aspectRatio length] > 0) {
+            self.aspectRatio = aspectRatio;
+        } else {
+            self.aspectRatio = @"3:4";
+    }
 
     if (![self deviceHasUltraWideCamera] && [cameraMode isEqualToString:@"wide"]) {
         if (completion) {
@@ -228,19 +269,22 @@
                 // Create a new input with the ultra-wide camera
                 NSError *error = nil;
                 AVCaptureDeviceInput *ultraWideVideoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:ultraWideCamera error:&error];
-                
-                if (!error) {
+                if (!error && [self.session canAddInput:ultraWideVideoDeviceInput]) {
                     // Add the new input to the session
-                    if ([self.session canAddInput:ultraWideVideoDeviceInput]) {
-                        [self.session addInput:ultraWideVideoDeviceInput];
-                        self.videoDeviceInput = ultraWideVideoDeviceInput;
-                        __block AVCaptureVideoOrientation orientation;
-                        dispatch_sync(dispatch_get_main_queue(), ^{
-                            orientation = [self getCurrentOrientation];
-                        });
-                        [self updateOrientation:orientation];
-                        self.device = ultraWideCamera;
-                        cameraSwitched = TRUE;
+                    [self.session addInput:ultraWideVideoDeviceInput];
+                    self.videoDeviceInput = ultraWideVideoDeviceInput;
+                    __block AVCaptureVideoOrientation orientation;
+                    dispatch_sync(dispatch_get_main_queue(), ^{
+                        orientation = [self getCurrentOrientation];
+                    });
+                    [self updateOrientation:orientation];
+                    self.device = ultraWideCamera;
+                    cameraSwitched = TRUE;
+
+                    // Update session preset based on new targetSize and aspectRatio
+                    AVCaptureSessionPreset calculatedPreset = [CameraSessionManager calculateResolution:self.targetSize aspectRatio:self.aspectRatio];
+                    if ([self.session canSetSessionPreset:calculatedPreset]) {
+                        [self.session setSessionPreset:calculatedPreset];
                     } else {
                         NSLog(@"Failed to add ultra-wide input to session");
                     }
@@ -251,7 +295,6 @@
                 NSLog(@"Ultra-wide camera not found");
             }
         }
-        
         completion ? completion(cameraSwitched): NULL;
     });
 }

--- a/src/ios/SimpleCameraPreview.h
+++ b/src/ios/SimpleCameraPreview.h
@@ -10,7 +10,6 @@
     CLLocation* currentLocation;
 }
 
-- (void) setOptions:(CDVInvokedUrlCommand*)command;
 - (void) enable:(CDVInvokedUrlCommand*)command;
 - (void) disable:(CDVInvokedUrlCommand*)command;
 - (void) capture:(CDVInvokedUrlCommand*)command;

--- a/src/ios/SimpleCameraPreview.m
+++ b/src/ios/SimpleCameraPreview.m
@@ -11,22 +11,6 @@
 
 BOOL torchActivated = false;
 
-- (void) setOptions:(CDVInvokedUrlCommand*)command {
-    NSDictionary* config = command.arguments[0];
-    @try {
-        if (config[@"targetSize"] != [NSNull null] && ![config[@"targetSize"] isEqual: @"null"]) {
-            NSInteger targetSize = ((NSNumber*)config[@"targetSize"]).intValue;
-            AVCaptureSessionPreset calculatedPreset = [CameraSessionManager calculateResolution:targetSize];
-            NSArray *calculatedPresetArray = [[[NSString stringWithFormat: @"%@", calculatedPreset] stringByReplacingOccurrencesOfString:@"AVCaptureSessionPreset" withString:@""] componentsSeparatedByString:@"x"];
-            float height = [calculatedPresetArray[0] floatValue];
-            float width = [calculatedPresetArray[1] floatValue];
-            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[NSString stringWithFormat:@"%f", (height / width)]];
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-        }
-    } @catch(NSException *exception) {
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"targetSize not well defined"] callbackId:command.callbackId];
-    }
-}
 
 - (void) enable:(CDVInvokedUrlCommand*)command {
     self.onCameraEnabledHandlerId = command.callbackId;
@@ -81,6 +65,10 @@ BOOL torchActivated = false;
             NSString *direction = config[@"direction"];
             if (direction && [direction length] > 0) {
                 [setupSessionOptions setValue:direction forKey:@"direction"];
+            }
+            NSString *aspectRatio = config[@"aspectRatio"];
+            if (aspectRatio && [aspectRatio length] > 0) {
+                [setupSessionOptions setValue:aspectRatio forKey:@"aspectRatio"];
             }
         } @catch(NSException *exception) {
             [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"targetSize not well defined"] callbackId:command.callbackId];
@@ -180,24 +168,31 @@ BOOL torchActivated = false;
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         return;
     }
-    
+    NSString *aspectRatio = options[@"aspectRatio"];
+    if (aspectRatio == nil) {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Aspect ratio missing"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        return;
+    }
     if (self.sessionManager == nil) {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera is closed, cannot switch camera"];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         return;
-    } 
+    }
     
     [self.sessionManager switchCameraTo:options completion:^(BOOL success) {
         if (success) {
-            NSLog(@"Camera switched successfully");
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self _setSize:command];
+            });
+           
             CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             return;
         } 
-        
-         NSLog(@"Failed to switch camera");
-            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Failed to switch camera"];
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Failed to switch camera"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
 }
 

--- a/www/SimpleCameraPreview.js
+++ b/www/SimpleCameraPreview.js
@@ -45,10 +45,6 @@ SimpleCameraPreview.initVideoCallback = function (onSuccess, onError, callback) 
         );
 }
 
-SimpleCameraPreview.setOptions = function (options, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "setOptions", [options]);
-};
-
 SimpleCameraPreview.enable = function (options, onSuccess, onError) {
   exec(onSuccess, onError, PLUGIN_NAME, "enable", [options]);
 };


### PR DESCRIPTION
Refactors resolution calculation to use supported camera resolutions and selects the closest match to the target size. 

Refactor plugin to remove deprecated method:

```java
 imageCapture = new ImageCapture.Builder()
                .setTargetResolution(targetResolution)
```
and use newer methods provided by this documentation: 
https://developer.android.com/reference/androidx/camera/core/resolutionselector/ResolutionSelector
https://developer.android.com/reference/androidx/camera/core/resolutionselector/AspectRatioStrategy

Introduces `aspectX` and `aspectY` parameters to allow customization of the camera's aspect ratio. Updates resolution 
calculation logic to respect these parameters and dynamically select the closest supported aspect ratio.

Enhances flexibility and improves compatibility with various camera configurations.
