### PR TITLE
Prevent adding microphone to session if in use.

### DIFF
--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -25,6 +25,7 @@
 @property (nonatomic) dispatch_queue_t sessionQueue;
 @property (nonatomic) AVCaptureDevicePosition defaultCamera;
 @property (nonatomic) NSInteger defaultFlashMode;
+@property (nonatomic) bool audioConfigured;
 @property (nonatomic) AVCaptureDevice *device;
 @property (nonatomic) AVCaptureDeviceInput *videoDeviceInput;
 @property (nonatomic) AVCapturePhotoOutput *imageOutput;

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -5,6 +5,7 @@
     if (self = [super init]) {
         // Create the AVCaptureSession
         self.session = [AVCaptureSession new];
+        self.audioConfigured = false;
         self.sessionQueue = dispatch_queue_create("session queue", DISPATCH_QUEUE_SERIAL);
         if ([self.session canSetSessionPreset:AVCaptureSessionPresetPhoto]) {
             [self.session setSessionPreset:AVCaptureSessionPresetPhoto];
@@ -112,6 +113,7 @@
                     } else {
                         NSLog(@"Error adding audio input: %@", audioError.localizedDescription);
                     }
+                    self.audioConfigured = true;
                 }
 
                 if ([self.session canAddOutput:self.movieFileOutput]) {

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -103,14 +103,15 @@
                 }
                 
                 AVCaptureVideoDataOutput *dataOutput = [AVCaptureVideoDataOutput new];
-                
-                AVCaptureDevice *audioDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
-                NSError *audioError = nil;
-                AVCaptureDeviceInput *audioInput = [AVCaptureDeviceInput deviceInputWithDevice:audioDevice error:&audioError];
-                if (audioInput && [self.session canAddInput:audioInput]) {
-                    [self.session addInput:audioInput];
-                } else {
-                    NSLog(@"Error adding audio input: %@", audioError.localizedDescription);
+                if ([[AVAudioSession sharedInstance] inputNumberOfChannels] == 0) {
+                    AVCaptureDevice *audioDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
+                    NSError *audioError = nil;
+                    AVCaptureDeviceInput *audioInput = [AVCaptureDeviceInput deviceInputWithDevice:audioDevice error:&audioError];
+                    if (audioInput && [self.session canAddInput:audioInput]) {
+                        [self.session addInput:audioInput];
+                    } else {
+                        NSLog(@"Error adding audio input: %@", audioError.localizedDescription);
+                    }
                 }
 
                 if ([self.session canAddOutput:self.movieFileOutput]) {


### PR DESCRIPTION
We were not able to use camera when on call. 

Why?
Because we were trying to add microphone to the camera session when it was in use and it crashed the application.