### PR TITLE
Ios issues front 4k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.42](https://github.com/spoonconsulting/cordova-plugin-simple-camera-preview/compare/2.0.41...2.0.42) (2025-06-27)
+* **iOS:** Fix front camera for device without 4k 
+
 ## [2.0.41](https://github.com/spoonconsulting/cordova-plugin-simple-camera-preview/compare/2.0.40...2.0.41) (2025-05-28)
 * **iOS:** Allow use of camera when on call and prevent crashing when cancelling scan
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spoonconsulting/cordova-plugin-simple-camera-preview",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spoonconsulting/cordova-plugin-simple-camera-preview",
-      "version": "2.0.41",
+      "version": "2.0.42",
       "license": "Apache 2.0",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spoonconsulting/cordova-plugin-simple-camera-preview",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "description": "Cordova plugin that allows camera interaction from HTML code for showing camera preview below or on top of the HTML.",
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="@spoonconsulting/cordova-plugin-simple-camera-preview" version="2.0.41" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="@spoonconsulting/cordova-plugin-simple-camera-preview" version="2.0.42" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
   <name>cordova-plugin-simple-camera-preview</name>
   <description>Cordova plugin that allows camera interaction from HTML code. Show camera preview popup on top of the HTML.</description>

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -18,6 +18,7 @@
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
 - (AVCaptureSessionPreset)calculateResolution:(NSInteger)targetSize aspectRatio:(NSString *)aspectRatio;
 - (UIInterfaceOrientation) getOrientation;
+- (AVCaptureSessionPreset)validateCameraPreset:(AVCaptureSessionPreset)preset;
 
 @property (atomic) CIFilter *ciFilter;
 @property (nonatomic) NSLock *filterLock;

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -207,7 +207,10 @@
 }
 
 - (AVCaptureSessionPreset)validateCameraPreset:(AVCaptureSessionPreset)preset camera:(AVCaptureDevice *)camera {
-    return [camera supportsAVCaptureSessionPreset:preset] ? preset : AVCaptureSessionPreset1280x720;
+    if ([self.aspectRatio isEqualToString:@"9:16"]) {
+        return [camera supportsAVCaptureSessionPreset:preset] ? preset : AVCaptureSessionPreset1280x720;
+    }
+    return [camera supportsAVCaptureSessionPreset:preset] ? preset : AVCaptureSessionPresetPhoto;
 }
 
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation {
@@ -296,7 +299,6 @@
                     [self updateOrientation:orientation];
                     self.device = selectedCamera;
                     cameraSwitched = TRUE;
-                    // Update session preset based on new targetSize and aspectRatio
                 } else {
                     NSLog(@"Error creating ultra-wide device input: %@", error.localizedDescription);
                 }

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -55,11 +55,10 @@
                     self.defaultCamera = AVCaptureDevicePositionBack;
                 }
                 
-                AVCaptureDevice *videoDevice;
-                videoDevice = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInWideAngleCamera];
+                self.device = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInWideAngleCamera];
                 if ([options[@"lens"] isEqual:@"wide"] && ![options[@"direction"] isEqual:@"front"] && [self deviceHasUltraWideCamera]) {
                     if (@available(iOS 13.0, *)) {
-                        videoDevice = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+                        self.device = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInUltraWideCamera];
                     }
                 }
 
@@ -69,10 +68,10 @@
                        self.aspectRatio = aspectRatio;
                    }
 
-                if ([videoDevice hasFlash]) {
-                    if ([videoDevice lockForConfiguration:&error]) {
+                if ([self.device hasFlash]) {
+                    if ([self.device lockForConfiguration:&error]) {
                         photoSettings.flashMode = AVCaptureFlashModeAuto;
-                        [videoDevice unlockForConfiguration];
+                        [self.device unlockForConfiguration];
                     } else {
                         NSLog(@"%@", error);
                         success = FALSE;
@@ -87,7 +86,7 @@
                 if (options) {
                     NSInteger targetSize = ((NSNumber*)options[@"targetSize"]).intValue;
                     self.targetSize = targetSize;
-                    AVCaptureSessionPreset calculatedPreset = [self calculateResolution:self.targetSize aspectRatio:self.aspectRatio camera:videoDevice];
+                    AVCaptureSessionPreset calculatedPreset = [self calculateResolution:self.targetSize aspectRatio:self.aspectRatio];
                     if ([self.session canSetSessionPreset:calculatedPreset]) {
                         [self.session setSessionPreset:calculatedPreset];
                     }
@@ -95,7 +94,7 @@
 
                 [self.session beginConfiguration];
 
-                AVCaptureDeviceInput *videoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:videoDevice error:&error];
+                AVCaptureDeviceInput *videoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:self.device error:&error];
                 
                 if ([self.session canAddInput:videoDeviceInput]) {
                     [self.session addInput:videoDeviceInput];
@@ -141,8 +140,6 @@
                     orientation=[self getCurrentOrientation];
                 });
                 [self updateOrientation:orientation];
-                self.device = videoDevice;
-                
                 completion(success);
             });
         }else{
@@ -159,7 +156,7 @@
     });
 }
 
-- (AVCaptureSessionPreset)calculateResolution:(NSInteger)targetSize aspectRatio:(NSString *)aspectRatio camera:(AVCaptureDevice *)camera {
+- (AVCaptureSessionPreset) calculateResolution:(NSInteger)targetSize aspectRatio:(NSString *)aspectRatio {
     // Define the available presets along with their native widths and aspect ratios.
     NSArray<NSDictionary *> *presets = @[
         @{@"preset": AVCaptureSessionPreset3840x2160, @"width": @(3840), @"aspect": @"9:16"},
@@ -183,7 +180,7 @@
         if ([normalizedAspect isEqualToString:@"3:4"])
             return AVCaptureSessionPresetPhoto;
         else
-            return [self validateCameraPreset: (AVCaptureSessionPreset)candidates.firstObject[@"preset"] camera:camera];
+            return [self validateCameraPreset: (AVCaptureSessionPreset)candidates.firstObject[@"preset"]];
     }
     
     // Otherwise, find which candidate's width is closest to the requested targetSize.
@@ -200,17 +197,17 @@
 
     // Return the preset of the closest match.
     if (bestMatch) {
-        return [self validateCameraPreset: bestMatch[@"preset"] camera:camera];
+        return [self validateCameraPreset: bestMatch[@"preset"]];
     } else {
-        return [self validateCameraPreset: candidates.firstObject[@"preset"] camera:camera];
+        return [self validateCameraPreset: candidates.firstObject[@"preset"]];
     }
 }
 
-- (AVCaptureSessionPreset)validateCameraPreset:(AVCaptureSessionPreset)preset camera:(AVCaptureDevice *)camera {
+- (AVCaptureSessionPreset) validateCameraPreset:(AVCaptureSessionPreset)preset {
     if ([self.aspectRatio isEqualToString:@"9:16"]) {
-        return [camera supportsAVCaptureSessionPreset:preset] ? preset : AVCaptureSessionPreset1280x720;
+        return [self.device supportsAVCaptureSessionPreset:preset] ? preset : AVCaptureSessionPreset1280x720;
     }
-    return [camera supportsAVCaptureSessionPreset:preset] ? preset : AVCaptureSessionPresetPhoto;
+    return [self.device supportsAVCaptureSessionPreset:preset] ? preset : AVCaptureSessionPresetPhoto;
 }
 
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation {
@@ -269,25 +266,24 @@
     dispatch_async(self.sessionQueue, ^{
         BOOL cameraSwitched = FALSE;
         if (@available(iOS 13.0, *)) {
-            AVCaptureDevice *selectedCamera;
             if([cameraMode isEqualToString:@"wide"]) {
-                selectedCamera = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInUltraWideCamera];
+                self.device = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInUltraWideCamera];
             } else {
-                selectedCamera = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInWideAngleCamera];
+                self.device = [self cameraWithPosition:self.defaultCamera captureDeviceType:AVCaptureDeviceTypeBuiltInWideAngleCamera];
             }
-            AVCaptureSessionPreset calculatedPreset = [self calculateResolution:self.targetSize aspectRatio:self.aspectRatio camera:selectedCamera];
+            AVCaptureSessionPreset calculatedPreset = [self calculateResolution:self.targetSize aspectRatio:self.aspectRatio];
             if ([self.session canSetSessionPreset:calculatedPreset]) {
                 [self.session setSessionPreset:calculatedPreset];
             } else {
                 NSLog(@"Failed to add ultra-wide input to session");
             }
-            if (selectedCamera) {
+            if (self.device) {
                 // Remove the current input
                 [self.session removeInput:self.videoDeviceInput];
                 
                 // Create a new input with the ultra-wide camera
                 NSError *error = nil;
-                AVCaptureDeviceInput *selectedCameraInput = [AVCaptureDeviceInput deviceInputWithDevice:selectedCamera error:&error];
+                AVCaptureDeviceInput *selectedCameraInput = [AVCaptureDeviceInput deviceInputWithDevice:self.device error:&error];
                 if (!error && [self.session canAddInput:selectedCameraInput]) {
                     // Add the new input to the session
                     [self.session addInput:selectedCameraInput];
@@ -297,7 +293,6 @@
                         orientation = [self getCurrentOrientation];
                     });
                     [self updateOrientation:orientation];
-                    self.device = selectedCamera;
                     cameraSwitched = TRUE;
                 } else {
                     NSLog(@"Error creating ultra-wide device input: %@", error.localizedDescription);

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -275,7 +275,7 @@
             if ([self.session canSetSessionPreset:calculatedPreset]) {
                 [self.session setSessionPreset:calculatedPreset];
             } else {
-                NSLog(@"Failed to add ultra-wide input to session");
+                NSLog(@"Failed to add sesion preset: %@", calculatedPreset);
             }
             if (self.device) {
                 // Remove the current input

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -275,7 +275,7 @@
             if ([self.session canSetSessionPreset:calculatedPreset]) {
                 [self.session setSessionPreset:calculatedPreset];
             } else {
-                NSLog(@"Failed to add sesion preset: %@", calculatedPreset);
+                NSLog(@"Failed to set session preset: %@", calculatedPreset);
             }
             if (self.device) {
                 // Remove the current input


### PR DESCRIPTION
Currently, the camera implementation attempts to use 4K resolution (3840x2160) on iOS devices without first verifying if the device supports this resolution, particularly for front-facing cameras. This can lead to inconsistent behavior for some iOS devices.

### Technical Details:

- Some iOS devices, especially older models, don't support 4K resolution on their front cameras
- Current implementation doesn't properly handle fallback to lower resolutions

### Comments on implementation ?

To fix this i have added a method validateCameraPreset that will check if the device support the preset selected, else it will return a fallback resolution (For aspect ratio 3:4: it will return AVCaptureSessionPresetPhoto, for 9:16 it will return AVCaptureSessionPreset1280x720)