### PR TITLE
Ipad capture bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.47](https://github.com/spoonconsulting/cordova-plugin-simple-camera-preview/compare/2.0.46...2.0.47) (2025-08-24)
+* **IOS:** Fix capture bug for ipad
+
 ## [2.0.46](https://github.com/spoonconsulting/cordova-plugin-simple-camera-preview/compare/2.0.45...2.0.46) (2025-08-22)
 * **IOS:** Improve torch error reporting 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spoonconsulting/cordova-plugin-simple-camera-preview",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spoonconsulting/cordova-plugin-simple-camera-preview",
-      "version": "2.0.46",
+      "version": "2.0.47",
       "license": "Apache 2.0",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spoonconsulting/cordova-plugin-simple-camera-preview",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "description": "Cordova plugin that allows camera interaction from HTML code for showing camera preview below or on top of the HTML.",
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="@spoonconsulting/cordova-plugin-simple-camera-preview" version="2.0.46" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="@spoonconsulting/cordova-plugin-simple-camera-preview" version="2.0.47" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
   <name>cordova-plugin-simple-camera-preview</name>
   <description>Cordova plugin that allows camera interaction from HTML code. Show camera preview popup on top of the HTML.</description>


### PR DESCRIPTION
Could not capture images on Ipad or devices that doesnt have flash.
The app was crashing when attempting to capture images on devices without flash capabilities. 

Implementation :
Added proper handling for devices without flash by including an else clause that:
- Logs when flash configuration is skipped
- Calls the completion callback with YES to allow capture to proceed
- Maintains compatibility with devices that do have flash