### PR TITLE
Fix black screen 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -59,6 +59,10 @@
       <string>This App requires access to your location to add GPS exif to captured images.</string>
     </config-file>
 
+    <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
+      <string>This App requires microphone access to record videos with audio.</string>
+    </config-file>
+
     <header-file src="src/ios/SimpleCameraPreview.h" />
     <source-file src="src/ios/SimpleCameraPreview.m" />
     <header-file src="src/ios/CameraSessionManager.h" />

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -33,7 +33,7 @@
 @property (nonatomic) AVCaptureDeviceInput *videoDeviceInput;
 @property (nonatomic) AVCapturePhotoOutput *imageOutput;
 @property (nonatomic) AVCaptureVideoDataOutput *dataOutput;
-@property (nonatomic, weak) id delegate;
+@property (nonatomic, strong) id delegate;
 @property (nonatomic) AVCaptureMovieFileOutput *movieFileOutput;
 @property (nonatomic) NSTimer *videoTimer;
 @property (nonatomic) NSInteger targetSize;


### PR DESCRIPTION
## 🐛 The Bug

**Symptom:** iOS camera shows black screen and app crashes during initialization.

**Root Cause:** Race condition with weak delegate reference being deallocated.

## What Was Happening

### The Crash Sequence:
1. `CameraRenderController` created
2. Set as delegate on `CameraSessionManager` (weak reference)
3. `setupSession` called **asynchronously** on background queue
4. **Weak delegate deallocated** before background thread reaches it
5. **CRASH** when trying to call `setSampleBufferDelegate:` with NULL pointer


### Why fix Works:

1. **Strong reference** keeps `CameraRenderController` alive during async setup
2. Background queue can safely access delegate
3. Frames can be delivered to the delegate
4. Camera preview works!