### PR TITLE
Modify finding which candidate's width is closest to the requested ta…

### DIFF
--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -193,18 +193,20 @@
     NSInteger bestDiff = NSIntegerMax;
     for (NSDictionary *info in candidates) {
         NSInteger width = [info[@"width"] integerValue];
-        NSInteger diff = llabs((long)(width - targetSize));
-        if (diff < bestDiff) {
-            bestDiff = diff;
-            bestMatch = info;
-        }
+        if(targetSize>=width){
+            NSInteger diff = llabs((long)(width - targetSize));
+            if (diff < bestDiff) {
+                bestDiff = diff;
+                bestMatch = info;
+            }
+       }
     }
 
     // Return the preset of the closest match.
     if (bestMatch) {
         return [self validateCameraPreset: bestMatch[@"preset"]];
     } else {
-        return [self validateCameraPreset: candidates.firstObject[@"preset"]];
+        return [self validateCameraPreset: AVCaptureSessionPresetPhoto];
     }
 }
 


### PR DESCRIPTION
## Why ?
Change calculateResolution's method of finding which candidate's width is closest to the requested targetSize.

## Comments on implementation ?
Added if condition such that comparison is done between widths which are less or equal to targetSize.